### PR TITLE
Updating Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Sparklyballs <sparklyballs@linuxserver.io>
 ENV APTLIST="openjdk-7-jre-headless unifi"
 
 # install packages
-RUN echo "deb http://www.ubnt.com/downloads/unifi/debian stable ubiquiti" >> /etc/apt/sources.list && \
+RUN echo "deb http://www.ubnt.com/downloads/unifi/debian unifi5 ubiquiti" >> /etc/apt/sources.list && \
 echo "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen" >> /etc/apt/sources.list && \
 apt-key adv --keyserver keyserver.ubuntu.com --recv C0A52C50 && \
 apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10 && \


### PR DESCRIPTION
Per http://community.ubnt.com/t5/UniFi-Updates-Blog/UniFi-5-0-6-is-released/ba-p/1579716:

For Debian/Ubuntu users, please update your APT source (see HERE).
unifi-beta/unifi-rapid are obsoleted. The old repo has been removed.
use 'unifi5' in your source file, instead of 'stable' or 'unifi4'