### PR TITLE
switch to using .deb instead of repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,31 @@ ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
+# package versions
+ARG UNIFI_VER="5.5.19"
+
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
 
-# install packages
+# add mongo repo
 RUN \
- echo "deb http://www.ubnt.com/downloads/unifi/debian stable ubiquiti" >> /etc/apt/sources.list && \
- apt-key adv --keyserver keyserver.ubuntu.com --recv C0A52C50 && \
+ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
+ echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" >> /etc/apt/sources.list.d/mongo.list && \
+
+# install packages
  apt-get update && \
  apt-get install -y \
+	binutils \
+	jsvc \
+	mongodb-org-server \
 	openjdk-8-jre-headless \
-	unifi \
 	wget && \
+
+# install unifi
+ curl -o \
+ /tmp/unifi.deb -L\
+	"http://dl.ubnt.com/unifi/${UNIFI_VER}/unifi_sysvinit_all.deb" && \
+ dpkg -i /tmp/unifi.deb && \
 
 # cleanup
  apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Use `ubnt` as the password to login and `$address` is the IP address of the host
 
 ## Versions
 
++ **15.07.17:** Switch to using .deb package, no need to keep up with the unifi repo merry-go-round.
 + **05.07.17:** Change repo to stable. Remove execstack command, no longer required.
 + **18.03.17:** Fix execstack warning.
 + **14.10.16:** Add version layer information.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Use `ubnt` as the password to login and `$address` is the IP address of the host
 
 ## Versions
 
-+ **15.07.17:** Switch to using .deb package, no need to keep up with the unifi repo merry-go-round.
++ **15.07.17:** Update to 5.5.19 and switch to using .deb package, no need to keep up with the unifi repo merry-go-round.
 + **05.07.17:** Change repo to stable. Remove execstack command, no longer required.
 + **18.03.17:** Fix execstack warning.
 + **14.10.16:** Add version layer information.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ using a fixed point .deb download to install unifi, will require manual update of version variable
+ but ends the repo-go-round nonsense from unifi
+ using the mongod repo to install a later version than the standard ubuntu repo version
+ shaves 124 MB off the current latest version prior to this PR