### PR TITLE
Update default port suggestions to include STUN communication UDP port

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ docker create \
   -p 8443:8443 \
   -p 8843:8843 \
   -p 8880:8880 \
+  -p 3478:3478/udp \
   linuxserver/unifi
 ```
 
 ## Parameters
 
-`The parameters are split into two halves, separated by a colon, the left hand side representing the host and the right the container side. 
+`The parameters are split into two halves, separated by a colon, the left hand side representing the host and the right the container side.
 For example with a port -p external:internal - what this shows is the port mapping from internal to external of the container.
 So -p 8080:80 would expose port 80 from inside the container to be accessible from the host's IP on port 8080
 http://192.168.x.x:8080 would show you what's running INSIDE the container on port 80.`
@@ -47,6 +48,7 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 * `-p 8443` - port(s)
 * `-p 8843` - port(s)
 * `-p 8880` - port(s)
+* `-p 3478/udp` - port(s)
 * `-v /config` - where unifi stores it config files etc, needs 3gb free
 * `-e PGID` for GroupID - see below for explanation
 * `-e PUID` for UserID - see below for explanation
@@ -73,9 +75,9 @@ To adopt a Unifi Access Point, and get it to show up in the software, take these
 ```
 ssh ubnt@$AP-IP
 mca-cli
-set-inform http://$address:8080/inform 
+set-inform http://$address:8080/inform
 ```
-  
+
 Use `ubnt` as the password to login and `$address` is the IP address of the host you are running this container on and `$AP-IP` is the Access Point IP address.
 
 ## Info
@@ -84,7 +86,7 @@ Use `ubnt` as the password to login and `$address` is the IP address of the host
 * To monitor the logs of the container in realtime: `docker logs -f unifi`
 
 
-* container version number 
+* container version number
 
 `docker inspect -f '{{ index .Config.Labels "build_version" }}' unifi`
 


### PR DESCRIPTION
3478/udp needs to be forwarded to support the STUN communication protocol used by Unifi products. This fixes an error in 5.6.x controller versions. See: https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used

Although this repo is still pegged to 5.5.x version of the controller, this is still an issue. On 5.5.x versions of the controller the STUN protocol silently fails with no indication to the user. 

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

