### PR TITLE
Update Unifi to 5.6.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs"
 
 # package versions
-ARG UNIFI_VER="5.6.26"
+ARG UNIFI_VER="5.6.29"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Use `ubnt` as the password to login and `$address` is the IP address of the host
 
 ## Versions
 
++ **08.01.18:** Update to 5.6.29.
 + **15.12.17:** Update to 5.6.26.
 + **09.12.17:** Fix continuation lines.
 + **12.11.17:** Add STUN server port 3478 mapping to example.


### PR DESCRIPTION
Public release:
https://www.ubnt.com/download/unifi/unifi-ap-ac-pro/default/unifi-5629-controller-debianubuntu-linux

Changelog:
https://community.ubnt.com/t5/UniFi-Updates-Blog/UniFi-5-6-29-Stable-has-been-released/ba-p/2191996
