### PR TITLE
Add port 6789 to support throughput test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ COPY root/ /
 # Volumes and Ports
 WORKDIR /usr/lib/unifi
 VOLUME /config
-EXPOSE 8080 8081 8443 8843 8880 6789
+EXPOSE 8080 8081 8443 8843 8880

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ COPY root/ /
 # Volumes and Ports
 WORKDIR /usr/lib/unifi
 VOLUME /config
-EXPOSE 8080 8081 8443 8843 8880
+EXPOSE 8080 8081 8443 8843 8880 6789

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ docker create \
   -p 8443:8443 \
   -p 8843:8843 \
   -p 8880:8880 \
+  -p 6789:6789 \
   linuxserver/unifi
 ```
 
@@ -51,6 +52,7 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 * `-p 8443` - port(s)
 * `-p 8843` - port(s)
 * `-p 8880` - port(s)
+* `-p 6789` - port(s) For throughput test
 * `-v /config` - where unifi stores it config files etc, needs 3gb free
 * `-e PGID` for GroupID - see below for explanation
 * `-e PUID` for UserID - see below for explanation
@@ -99,6 +101,7 @@ Use `ubnt` as the password to login and `$address` is the IP address of the host
 
 ## Versions
 
++ **19.02.18:** Add port 6789 to support throughput test
 + **09.02.18:** Update to 5.6.30.
 + **08.02.18:** Use loop to simplify symlinks.
 + **08.01.18:** Update to 5.6.29.


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

Port 6789 needs to be exposed in order to support the throughput test using the iOS unifi app (I assume the feature is available on other apps)

![unifi port 6789](https://user-images.githubusercontent.com/4693852/36392474-327b7b5e-1560-11e8-8cf4-3fff56c2ba56.png)


