### PR TITLE
Update Unifi to 5.7.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs"
 
 # package versions
-ARG UNIFI_VER="5.6.30"
+ARG UNIFI_VER="5.7.20"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Use `ubnt` as the password to login and `$address` is the IP address of the host
 
 ## Versions
 
++ **14.03.18:** Update to 5.7.20.
 + **19.02.18:** Add port 6789 to support throughput test
 + **09.02.18:** Update to 5.6.30.
 + **08.02.18:** Use loop to simplify symlinks.


### PR DESCRIPTION
Closes: #48 

Public release (in download page):
https://www.ubnt.com/download/unifi/unifi-ap-ac-pro/uap-ac-pro/unifi-5630-controller-debianubuntu-linux

Changelog:
https://community.ubnt.com/t5/UniFi-Updates-Blog/UniFi-5-7-20-Stable-has-been-released/ba-p/2271529

**Can you please add a LTS tag from actual 5.6.x master (before merge), so I'll be able to pull request for next 5.6.x version to a LTS channel (code is waiting here: https://github.com/dam09fr/docker-unifi/tree/unifi-5.6.36-lts). Thank you in advance.**