### PR TITLE
Version bump to the latest LTS Stable (5.6.39)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs"
 
 # package versions
-ARG UNIFI_VER="5.6.37"
+ARG UNIFI_VER="5.6.39"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
https://community.ubnt.com/t5/UniFi-Updates-Blog/UniFi-5-6-39-LTS-Stable-Candidate-has-been-released/ba-p/2368843