### PR TITLE
Bump Unifi Version to 5.8.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs"
 
 # package versions
-ARG UNIFI_VER="5.6.39"
+ARG UNIFI_VER="5.8.24"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
Bump Unifi version to 5.8.24 - the latest (at time of writing) stable release.