### PR TITLE
Bump to 5.9.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs"
 
 # package versions
-ARG UNIFI_VER="5.8.30"
+ARG UNIFI_VER="5.9.29"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
Bump to new SDN version, per stable release: [UniFi SDN Controller 5.9.29 Stable has been released](https://community.ubnt.com/t5/UniFi-Updates-Blog/UniFi-SDN-Controller-5-9-29-Stable-has-been-released/ba-p/2516852)